### PR TITLE
Fix release flow in CI and document it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Pack extension
         id: pack
         run: |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ A Claude Desktop extension to connect to the Let's Do This MCP server.
 2. Open the Claude Desktop app. Go to Settings > Extensions, and drag the downloaded `.dxt` file into the window.
 3. Enter your API key when prompted.
 
+## Shipping new releases
+
+To ship a new release of the extension, use the automated [release](.github/workflows/release.yml) workflow.
+
+- Update the version number of the extension in the `manifest.json` file, as well as the `package.json` file.
+- Create and push a new commit with the updated release version.
+- Create a new release using the [`gh` CLI](https://cli.github.com/). Always create a new tag for a new release.
+
+```bash
+gh release create
+```
+
+If the automated release process fails for any reason, you can trigger a manual run of the workflow too.
+
 ---
 
 Copyright © 2025 Let's Do This


### PR DESCRIPTION
Adds a step to install dependencies in the release workflow before packaging the extension.
Also adds docs to the README to outline this process for all contributors.
